### PR TITLE
Correct invalid keywords.txt KEYWORD_TOKENTYPE

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,14 +1,14 @@
-ByteConvert	KEYWORD 1
+ByteConvert	KEYWORD1
 
-unsigned_int2byte	KEYWORD 2
-unsigned_bytes2int	KEYWORD 2
-unsigned_int2bytes_127	KEYWORD 2
-unsigned_bytes2int_127	KEYWORD 2
-long2byte	KEYWORD 2
-bytes2long	KEYWORD 2
-long2byte_127	KEYWORD 2
-bytes2long_127	KEYWORD 2
-int2bytes	KEYWORD 2
-bytes2int	KEYWORD 2
-int2bytes_127	KEYWORD 2
-bytes2int_127	KEYWORD 2
+unsigned_int2byte	KEYWORD2
+unsigned_bytes2int	KEYWORD2
+unsigned_int2bytes_127	KEYWORD2
+unsigned_bytes2int_127	KEYWORD2
+long2byte	KEYWORD2
+bytes2long	KEYWORD2
+long2byte_127	KEYWORD2
+bytes2long_127	KEYWORD2
+int2bytes	KEYWORD2
+bytes2int	KEYWORD2
+int2bytes_127	KEYWORD2
+bytes2int_127	KEYWORD2


### PR DESCRIPTION
Use of an invalid KEYWORD_TOKENTYPE value in keywords.txt causes the keyword to be colored by the default editor.function.style (as used by KEYWORD2, KEYWORD3, LITERAL2) in Arduino IDE 1.6.5 and newer. On Arduino IDE 1.6.4 and older this will cause the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keyword_tokentype